### PR TITLE
Fix bluesky post hashtags not appearing as clickable links.

### DIFF
--- a/social_posters/bluesky.py
+++ b/social_posters/bluesky.py
@@ -68,11 +68,15 @@ class PosterBluesky(SocialPoster):
             except Exception as exc:
                 return PostResult(success=False, error_message=str(exc))
 
+        text, facets = self._build_text_and_facets(post)
         record = {
             "$type": "app.bsky.feed.post",
-            "text": self._format_text(post),
+            "text": text,
             "createdAt": datetime.utcnow().isoformat() + "Z",
         }
+
+        if facets:
+            record["facets"] = facets
 
         if image_blob:
             record["embed"] = {
@@ -143,10 +147,33 @@ class PosterBluesky(SocialPoster):
             alt_text=f"Photo of {name}, a {pet.breed} available for adoption",
             tags=tags,
         )
-    def _format_text(self, post: Post) -> str:
-        text = post.text
-        if post.tags:
-            tags = " ".join(f"#{tag}" for tag in post.tags if tag)
-            text = f"{text}\n\n{tags}"
-        return text[:300]
+    def _build_text_and_facets(self, post: Post) -> tuple[str, list]:
+        body = post.text
+        facets = []
+
+        if not post.tags:
+            return body[:300], facets
+
+        tag_strings = [f"#{tag}" for tag in post.tags if tag]
+        tags_section = " ".join(tag_strings)
+        separator = "\n\n"
+
+        # Truncate body so the full text (body + separator + tags) fits in 300 chars.
+        max_body = 300 - len(separator) - len(tags_section)
+        full_text = f"{body[:max_body]}{separator}{tags_section}"
+
+        # Compute byte offsets (AT Protocol facets use UTF-8 byte positions).
+        encoded = full_text.encode("utf-8")
+        search_from = 0
+        for tag_str in tag_strings:
+            tag_bytes = tag_str.encode("utf-8")
+            idx = encoded.find(tag_bytes, search_from)
+            if idx != -1:
+                facets.append({
+                    "index": {"byteStart": idx, "byteEnd": idx + len(tag_bytes)},
+                    "features": [{"$type": "app.bsky.richtext.facet#tag", "tag": tag_str[1:]}],
+                })
+                search_from = idx + len(tag_bytes)
+
+        return full_text, facets
 

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -1,0 +1,29 @@
+from abstractions import Post
+from social_posters.bluesky import PosterBluesky
+
+
+class TestBuildTextAndFacets:
+    def setup_method(self):
+        self.poster = PosterBluesky.__new__(PosterBluesky)
+
+    def test_no_tags_produces_no_facets(self):
+        post = Post(text="Hello, world!")
+        text, facets = self.poster._build_text_and_facets(post)
+        assert text == "Hello, world!"
+        assert facets == []
+
+    def test_tags_produce_facets_with_correct_byte_offsets(self):
+        post = Post(text="Adopt me!", tags=["AdoptDontShop", "Boston", "DogsOfBluesky"])
+        text, facets = self.poster._build_text_and_facets(post)
+
+        assert text == "Adopt me!\n\n#AdoptDontShop #Boston #DogsOfBluesky"
+        assert len(facets) == 3
+
+        encoded = text.encode("utf-8")
+
+        for facet, tag_name in zip(facets, ["AdoptDontShop", "Boston", "DogsOfBluesky"]):
+            start = facet["index"]["byteStart"]
+            end = facet["index"]["byteEnd"]
+            assert encoded[start:end] == f"#{tag_name}".encode("utf-8")
+            assert facet["features"][0]["$type"] == "app.bsky.richtext.facet#tag"
+            assert facet["features"][0]["tag"] == tag_name


### PR DESCRIPTION
This pull request is for #58 to make the hashtags appear as clickable links in the Bluesky posts.

It adds the facets for the tags in the post, and a test to check the correct offsets for the facets.

I tested this manually from the command line and the post appears with clickable hashtags

<img width="530" height="675" alt="image" src="https://github.com/user-attachments/assets/94a11dcf-8b88-4012-ab64-ab08c031cb26" />

