### PR TITLE
Fixes the double-encoding problem with postalcode.

### DIFF
--- a/adoption_sources/rescue_groups.py
+++ b/adoption_sources/rescue_groups.py
@@ -74,14 +74,14 @@ class SourceRescueGroups(PetSource):
             "Content-Type": "application/vnd.api+json",
             "Authorization": self._api_key,
         }
-        payload = json.dumps({
+        payload = {
             "data": {
                 "filterRadius": {
                     "miles": self.radius_miles,
                     "postalcode": self.postal_code,
                 }
             }
-        })
+        }
 
 
         logger.info(


### PR DESCRIPTION
The payload does not need to be dumped to a string to be included in `requests.post`.  Double encoding it was causing the location `postal_code` to be bad data and we weren't getting adoptable pets near Boston.