### PR TITLE
Platform location config

### DIFF
--- a/abstractions.py
+++ b/abstractions.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Iterable
 
+from config import CITY_NAME, CITY_STATE
+
 
 # =============================================================================
 # Pet Ingestor Interface
@@ -120,7 +122,7 @@ class SocialPoster(ABC):
             text += f"\n\nAdopt {pet.name}: {pet.adoption_url}"
 
         city = ""
-        if pet.location != "Boston, MA":
+        if pet.location != f"{CITY_NAME}, {CITY_STATE}":
             city = pet.location.split(",")[0].capitalize()
 
         return Post(

--- a/adoption_sources/manual.py
+++ b/adoption_sources/manual.py
@@ -6,6 +6,7 @@ import json
 from typing import Iterable, Sequence
 
 from abstractions import AdoptablePet, PetSource
+from config import CITY_NAME, CITY_STATE
 
 _data_path = __file__.replace(".py", ".json")
 with open(_data_path) as _f:
@@ -18,7 +19,7 @@ class SourceManual(PetSource):
     def __init__(
         self,
         animals: Sequence[dict] | None = None,
-        location_label: str = "Boston, MA",
+        location_label: str = f"{CITY_NAME}, {CITY_STATE}",
         species: str = "dog",
     ) -> None:
         self._animals: Sequence[dict] = animals if animals is not None else MANUAL_SOURCE_DATA

--- a/adoption_sources/rescue_groups.py
+++ b/adoption_sources/rescue_groups.py
@@ -14,6 +14,7 @@ import json
 import requests
 
 from abstractions import AdoptablePet, PetSource
+from config import CITY_NAME, CITY_STATE, POSTAL_CODE
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +31,11 @@ class SourceRescueGroups(PetSource):
     def __init__(
         self,
         api_key: str | None = None,
-        postal_code: str = "02108",  # Boston
+        postal_code: str = POSTAL_CODE,
         radius_miles: int = 50,
         species: str = "dogs",  # "dogs" or "cats"
         limit: int = 25,
-        location_label: str = "Boston, MA",  # For display purposes
+        location_label: str = f"{CITY_NAME}, {CITY_STATE}",
     ):
         self._api_key = api_key or os.environ.get("CUTEPETSBOSTON_RESCUEGROUPS_API_KEY")
         self.postal_code = postal_code

--- a/config.py
+++ b/config.py
@@ -1,0 +1,4 @@
+CITY_NAME = "Boston"
+CITY_STATE = "MA"
+CITY_HASHTAGS = ["Boston"]
+POSTAL_CODE = "02108"

--- a/social_posters/bluesky.py
+++ b/social_posters/bluesky.py
@@ -4,6 +4,7 @@ import os
 import requests
 
 from abstractions import Post, PostResult, SocialPoster
+from config import CITY_HASHTAGS, CITY_NAME, CITY_STATE
 
 
 class PosterBluesky(SocialPoster):
@@ -120,7 +121,7 @@ class PosterBluesky(SocialPoster):
         text += "."
 
         city = ""
-        if pet.location != "Boston, MA":
+        if pet.location != f"{CITY_NAME}, {CITY_STATE}":
             city = pet.location.split(",")[0].capitalize()
 
         detail_parts = []
@@ -141,7 +142,7 @@ class PosterBluesky(SocialPoster):
             text += f"\n\nLearn more and adopt me: {pet.adoption_url}"
 
         species_tag = "DogsOfBluesky" if pet.species == "dog" else "CatsOfBluesky"
-        tags = ["AdoptDontShop", "Boston", city, species_tag]
+        tags = ["AdoptDontShop", *CITY_HASHTAGS, city, species_tag]
 
         return Post(
             text=text,


### PR DESCRIPTION
Adds `config.py` so forks for other cities can change location in one place instead of editing hardcoded values across the codebase.

Wires `CITY_NAME`, `CITY_STATE`, `CITY_HASHTAGS`, and `POSTAL_CODE` into `abstractions.py`, `rescue_groups.py`, `manual.py`, and `bluesky.py`. All 49 tests pass.