### PR TITLE
Cache pip requirements in GitHub Actions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install dependencies
         run: pip install --break-system-packages -r requirements.txt

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install dependencies
         run: pip install --break-system-packages -r requirements.txt


### PR DESCRIPTION
## Summary
- Adds `cache: 'pip'` to `actions/setup-python@v5` in both `dev.yml` and `prod.yml`, so pip installs reuse a cache keyed on `requirements.txt` instead of redownloading every run.

Closes #91

## Test plan
- [x] Ran `act` locally against `dev.yml` — setup-python accepts the input, pip install completes, `main.py --debugsources --debugposters` runs successfully.
- [ ] Confirm on the next push that the "Set up Python" step reports a cache hit on the second run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)