### PR TITLE
Add pytest CI workflow (closes #72)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install --break-system-packages -r requirements.txt
+
+      - name: Run pytest
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ outcome==1.3.0.post0
 plyer==2.1.0
 protobuf==3.20.3
 PySocks==1.7.1
+pytest==9.0.3
 python-dateutil==2.9.0.post0
 python-magic==0.4.27
 python-telegram-bot==22.6


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`.github/workflows/tests.yml`) that runs `pytest` on every PR and on pushes to `master`.
- Add `pytest==9.0.3` to `requirements.txt`.
- Add `pytest.ini` scoping test discovery to `tests/`, so the bare `pytest` command doesn't collect `manual_testing/mastodon_simple_test.py` (which hits a live API on import).

Addresses #72:
- [x] pytest included in the project
- [x] `tests/` folder with python tests (53 already exist and pass)
- [ ] PR merge blocked until tests pass — **needs a manual step on GitHub**

## Heads up — branch protection is NOT enabled by this PR
This PR adds the **check**, but it does not (and cannot) make it a **required** check. To actually block merges on a failing test run, a maintainer needs to:

1. Go to **Settings → Branches → Branch protection rules** for `master`
2. Enable **Require status checks to pass before merging**
3. Add the `pytest` check (from the new "Tests" workflow) to the required list

I'd suggest doing that *after* this PR merges, so the workflow exists and shows up in the picker. Until then, the check will run on PRs and be visible, but won't block merging.

## Test plan
- [ ] Verify the "Tests" workflow runs on this PR and goes green
- [ ] After merge, configure branch protection per above and confirm a failing test on a follow-up PR blocks merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)