### PR TITLE
Rename actions for clarity

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: RescueGroups API Post
+name: Debug Post
 
 on:
   push:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,4 +1,4 @@
-name: RescueGroups API Post
+name: Prod Account Post
 
 on:
   push:


### PR DESCRIPTION
Currently the dev and prod actions have the same name which seems to be a holdover from when we were testing the Rescuegroups API. In order to make it clearer what each action is for I suggest renaming them to reflect their current purposes.

<img width="397" height="451" alt="image" src="https://github.com/user-attachments/assets/25cfbe87-07af-4120-abc6-cf69d0cc0c56" />
