### PR TITLE
Retry RescueGroups API requests with backoff

### DIFF
--- a/adoption_sources/rescue_groups.py
+++ b/adoption_sources/rescue_groups.py
@@ -11,6 +11,8 @@ import re
 from typing import Iterator
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from abstractions import AdoptablePet, PetSource
 from config import CITY_NAME, CITY_STATE, POSTAL_CODE
@@ -20,6 +22,27 @@ logger = logging.getLogger(__name__)
 # Some rescues publish entries like "More Dogs Soon!" to point users at their
 # website; those should never be posted. Add new names here as we encounter them.
 PLACEHOLDER_NAMES: tuple[str, ...] = ("more dogs soon!",)
+
+# The RescueGroups API occasionally times out or returns a transient 5xx. A
+# single hiccup shouldn't fail the whole run, so retry a few times with
+# exponential backoff (0s, 2s, 4s, 8s between attempts).
+RETRY_TOTAL = 4
+RETRY_BACKOFF_FACTOR = 1
+
+
+def _session_with_retries() -> requests.Session:
+    """Build a requests Session that retries transient errors with backoff."""
+    retry = Retry(
+        total=RETRY_TOTAL,
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        status_forcelist=(429, 500, 502, 503, 504),
+        # We only POST, so POST must be opted in (it isn't retried by default).
+        allowed_methods=frozenset({"POST"}),
+        raise_on_status=False,
+    )
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+    return session
 
 
 class SourceRescueGroups(PetSource):
@@ -92,7 +115,8 @@ class SourceRescueGroups(PetSource):
             f"Fetching {self.species} from RescueGroups within {self.radius_miles} miles of {self.postal_code}"
         )
 
-        response = requests.post(url, json=payload, headers=headers, timeout=30)
+        session = _session_with_retries()
+        response = session.post(url, json=payload, headers=headers, timeout=30)
         response.raise_for_status()
 
         body = response.json()


### PR DESCRIPTION
## Summary

A scheduled prod run failed with a `requests.exceptions.ReadTimeout` from `api.rescuegroups.org` (see #116). Because `SourceRescueGroups` is the only non-debug source and `main.run()` only catches `ValueError`, a single transient timeout crashed the whole run and nothing was posted that day.

This mounts an `HTTPAdapter` with urllib3's `Retry` on the request session so transient failures are retried before giving up.

## Behavior

- Retries up to 4 times on connect/read **timeouts** (the exact failure from #116) and on transient statuses `429, 500, 502, 503, 504`.
- Exponential backoff between attempts: **0s, 2s, 4s, 8s** (`backoff_factor=1`).
- **POST** is explicitly added to `allowed_methods` — urllib3 does not retry POST by default.
- `raise_on_status=False` preserves the existing `response.raise_for_status()` error path, so a genuinely-failing request still surfaces an `HTTPError` as before.
- The 30s per-request timeout is unchanged; retries layer on top.

## Testing

- All 5 existing `tests/test_rescue_groups.py` tests pass.
- Verified the retry config at runtime (4 retries, correct backoff sequence, POST opt-in, status forcelist) against urllib3 2.6.3 / requests 2.32.5.

Note: the existing suite doesn't cover the network path (tests only exercise `_parse_animal`), so this change isn't covered by an automated test. Happy to add one that mocks a timeout-then-success if desired.

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)