### PR TITLE
Add service status link to website footer (#122)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -81,9 +81,14 @@
   </main>
 
   <footer>
-    Made with <span aria-label="love">&hearts;</span> by
-    <a href="https://www.codeforboston.org/" target="_blank" rel="noopener">Code for Boston</a>
-    volunteers.
+    <p>
+      Made with <span aria-label="love">&hearts;</span> by
+      <a href="https://www.codeforboston.org/" target="_blank" rel="noopener">Code for Boston</a>
+      volunteers.
+    </p>
+    <p>
+      <a href="https://stats.uptimerobot.com/5SyexhEIaG" target="_blank" rel="noopener">Service status &amp; uptime &rarr;</a>
+    </p>
   </footer>
 
   <script>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -246,3 +246,7 @@ footer {
   color: var(--muted);
   font-size: 0.9rem;
 }
+
+footer p {
+  margin: 0.35rem 0;
+}


### PR DESCRIPTION
## What

Adds a link to our public [UptimeRobot status page](https://stats.uptimerobot.com/5SyexhEIaG) in the website footer, so visitors can check the bot's uptime and current operational status.

Addresses #122 (status check / uptime monitoring for the site). The UptimeRobot monitor itself handles the Pingdom-style checks and `#cute-pets-boston-alerts` notifications; this PR surfaces that status page from the site.

## Changes

- `docs/index.html` — footer now has a "Service status & uptime →" link alongside the existing credit line.
- `docs/styles.css` — minor `footer p` spacing so the two footer lines sit nicely.

## Verification

Served `docs/` locally and confirmed the footer renders both lines and the link points to the status page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)