### PR TITLE
Fix Bluesky Small Dog adoption links

### DIFF
--- a/social_posters/bluesky.py
+++ b/social_posters/bluesky.py
@@ -162,16 +162,14 @@ class PosterBluesky(SocialPoster):
         tags_section = " ".join(tag_strings)
         # Truncate body so the full text (body + separators + tags) fits in limit chars.
         max_body = limit - (len(separator) + len(tags_section) if tags_section else 0)
-        # When the link URL is embedded in the body and would be truncated, preserve it
-        # by truncating only the prefix before it.
+        # When the link URL is embedded in the body and would be truncated,
+        # keep the full URL and trim text before it instead.
         if post.link and post.link in body:
-            link_pos = body.find(post.link)
-            if link_pos >= max_body:
-                suffix = body[link_pos:]
-                available = max_body - len(suffix)
-                truncated_body = (body[:available] + suffix) if available >= 0 else body[:max_body]
-            else:
-                truncated_body = body[:max_body]
+            truncated_body = self._truncate_body_preserving_link(
+                body,
+                post.link,
+                max_body,
+            )
         else:
             truncated_body = body[:max_body]
         full_text = f"{truncated_body}{separator}{tags_section}" if tags_section else truncated_body
@@ -205,4 +203,37 @@ class PosterBluesky(SocialPoster):
 
         facets.sort(key=lambda f: f["index"]["byteStart"])
         return full_text, facets
+
+    @staticmethod
+    def _truncate_body_preserving_link(body: str, link: str, limit: int) -> str:
+        if len(body) <= limit:
+            return body
+
+        link_pos = body.find(link)
+        if link_pos == -1:
+            return body[:limit]
+
+        link_end = link_pos + len(link)
+        if link_end <= limit:
+            return body[:limit]
+
+        if len(link) > limit:
+            return body[:limit]
+
+        prefix = body[:link_pos].rstrip()
+        separator = " " if prefix else ""
+        prefix_limit = limit - len(link) - len(separator)
+
+        if prefix_limit <= 0:
+            return link
+
+        trimmed_prefix = prefix[:prefix_limit].rstrip()
+        if len(prefix) > prefix_limit:
+            line_start = trimmed_prefix.rfind("\n")
+            clean_prefix = trimmed_prefix[:line_start].rstrip() if line_start != -1 else ""
+            if clean_prefix:
+                trimmed_prefix = clean_prefix
+
+        separator = " " if trimmed_prefix else ""
+        return f"{trimmed_prefix}{separator}{link}"
 

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -57,6 +57,28 @@ class TestBuildTextAndFacets:
         assert len(link_facets) == 1
         assert link_facets[0]["features"][0]["uri"] == url
 
+    def test_url_that_crosses_body_limit_is_preserved_with_tags(self):
+        url = "https://www.smalldogrescuene.org/adoptable-dogs/#action_0=pet&animalID_0=22537020&petIndex_0=-1"
+        tags = ["AdoptDontShop", "Boston", "Cranston", "DogsOfBluesky"]
+        tags_section = " ".join(f"#{t}" for t in tags)
+        body = (
+            "Hi, I'm Glandis in TX! I'm a Chihuahua / Mixed (short coat) "
+            "looking for a forever home in Cranston, RI.\n\n"
+            "8 Months - Female - Small size\n\n"
+            f"Learn more and adopt me: {url}"
+        )
+        post = Post(text=body, tags=tags, link=url)
+        text, facets = self.poster._build_text_and_facets(post)
+
+        assert url in text
+        assert "petIndex_0=-1" in text
+        assert "Learn more and ado " not in text
+        assert text.endswith(f"\n\n{tags_section}")
+        assert len(text) <= 300
+        link_facets = [f for f in facets if f["features"][0]["$type"] == "app.bsky.richtext.facet#link"]
+        assert len(link_facets) == 1
+        assert link_facets[0]["features"][0]["uri"] == url
+
     def test_tags_produce_facets_with_correct_byte_offsets(self):
         post = Post(text="Adopt me!", tags=["AdoptDontShop", "Boston", "DogsOfBluesky"])
         text, facets = self.poster._build_text_and_facets(post)


### PR DESCRIPTION
## Summary
- Preserve full adoption URLs when Bluesky post text must be trimmed to the 300-character limit
- Avoid leaving partial lead-in text before a preserved long URL
- Add regression coverage for the Small Dog Rescue deep link that was being truncated after `petInde`

## Root cause
Small Dog Rescue deep-link reconstruction produced the correct URL, including `petIndex_0=-1`, but Bluesky formatting sliced the post body before the reconstructed URL finished. That published a broken adoption link.
<img width="615" height="772" alt="image" src="https://github.com/user-attachments/assets/cf16e5ec-831a-44aa-b56f-e89069d125f3" />

