### PR TITLE
added concurrency group to prevent concurrent workflow executions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,6 +10,12 @@ on:
 permissions:
       actions: read
 
+# Limits to executing one workflow in a concurrency group at any time
+# Will queue 1 PENDING workflow run. New incoming runs cancel & replace the pending run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  queue: single
+
 jobs:
   run-cute-pets:
     runs-on: ubuntu-latest
@@ -31,7 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fetches the ID of the last completed run for the current workflow
+          # Fetches the ID of this branch's last completed run for the current workflow
           PREVIOUS_RUN_ID=$(gh run list \
           --branch "${{ github.ref_name }}" \
           --workflow "${{ github.workflow }}" \

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -8,6 +8,12 @@ on:
 
 permissions:
       actions: read
+      
+# Limits to executing one workflow in a concurrency group at any time
+# Will queue 1 PENDING workflow run. New incoming runs cancel & replace the pending run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  queue: single
 
 jobs:
   run-cute-pets:
@@ -30,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fetches the ID of the last completed run for the current workflow
+          # Fetches the ID of this branch's last completed run for the current workflow
           PREVIOUS_RUN_ID=$(gh run list \
           --branch "${{ github.ref_name }}" \
           --workflow "${{ github.workflow }}" \


### PR DESCRIPTION
Added a concurrency group to the Prod and Dev workflows. Building the key as a composite of `workflow` + `ref` allows each branch/tag to maintain it's own concurrency. 

Tested functionality with Dev and the workflows queue properly
<img width="1504" height="184" alt="image" src="https://github.com/user-attachments/assets/3b3b26ba-eb9d-4082-a749-6041440eab60" />
