### PR TITLE
feat: make debug flags configurable via workflow_dispatch inputs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,6 +6,17 @@ on:
       - '**'
       - '!master'
   workflow_dispatch:
+    inputs:
+      debugsources:
+        description: 'Use mock data sources instead of live RescueGroups API'
+        required: false
+        type: boolean
+        default: true
+      debugposters:
+        description: 'Skip posting to real social accounts (use test/mock posters)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   actions: read
@@ -65,9 +76,14 @@ jobs:
           BLUESKY_PASSWORD: ${{ secrets.BLUESKY_TEST_PASSWORD }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           APP_ENV: dev
+          DEBUG_SOURCES: ${{ inputs.debugsources != false }}
+          DEBUG_POSTERS: ${{ inputs.debugposters != false }}
         run: |
           #In order to create posts on the test accounts remove the --debugposters debug flag
-          python ./main.py --debugsources --debugposters
+          FLAGS=""
+          if [ "$DEBUG_SOURCES" = "true" ]; then FLAGS="$FLAGS --debugsources"; fi
+          if [ "$DEBUG_POSTERS" = "true" ]; then FLAGS="$FLAGS --debugposters"; fi
+          python ./main.py $FLAGS
 
       - name: Upload database artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Added debugsources and debugposters as boolean inputs on workflow_dispatch, so both flags can be toggled when manually running the dev workflow, per the GitHub Actions docs referenced in the issue.

Both inputs default to true, matching the existing hardcoded behavior. The "Call RescueGroups API" step now builds the --debugsources/--debugposters flags dynamically from those inputs instead of hardcoding them. On a normal push trigger (not manual dispatch), inputs.debugsources is undefined, and undefined != false evaluates to true, so push-triggered runs behave exactly as before — no regression there.

Validated the YAML parses correctly with yaml.safe_load.

Closes #150