### PR TITLE
Fix Instagram token exposure in request logging

### DIFF
--- a/social_posters/instagram.py
+++ b/social_posters/instagram.py
@@ -21,6 +21,10 @@ class PosterInstagram(SocialPoster):
     def platform_name(self) -> str:
         return "Instagram"
 
+    @property
+    def _authorization_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.access_token}"}
+
     def authenticate(self) -> bool:
         if not self._is_available:
             print("Instagram: credentials not set (INSTAGRAM_BUSINESS_ACCOUNT_ID or INSTAGRAM_PAGE_ACCESS_TOKEN missing)")
@@ -28,7 +32,8 @@ class PosterInstagram(SocialPoster):
         try:
             response = requests.get(
                 f"{GRAPH_API_BASE}/{self.account_id}",
-                params={"fields": "id,username", "access_token": self.access_token},
+                params={"fields": "id,username"},
+                headers=self._authorization_headers,
                 timeout=10,
             )
             response.raise_for_status()
@@ -84,10 +89,10 @@ class PosterInstagram(SocialPoster):
         caption = self._format_caption(post)
         response = requests.post(
             f"{GRAPH_API_BASE}/{self.account_id}/media",
+            headers=self._authorization_headers,
             data={
                 "image_url": post.image_url,
                 "caption": caption,
-                "access_token": self.access_token,
             },
             timeout=30,
         )
@@ -98,9 +103,9 @@ class PosterInstagram(SocialPoster):
     def _publish_media(self, container_id: str) -> str:
         response = requests.post(
             f"{GRAPH_API_BASE}/{self.account_id}/media_publish",
+            headers=self._authorization_headers,
             data={
                 "creation_id": container_id,
-                "access_token": self.access_token,
             },
             timeout=30,
         )

--- a/tests/test_instagram.py
+++ b/tests/test_instagram.py
@@ -1,0 +1,79 @@
+from unittest.mock import Mock, patch
+
+from abstractions import Post
+from social_posters.instagram import GRAPH_API_BASE, PosterInstagram
+
+
+ACCESS_TOKEN = "secret-token"
+ACCOUNT_ID = "account-id"
+
+
+def build_poster(monkeypatch) -> PosterInstagram:
+    monkeypatch.setenv("INSTAGRAM_BUSINESS_ACCOUNT_ID", ACCOUNT_ID)
+    monkeypatch.setenv("INSTAGRAM_PAGE_ACCESS_TOKEN", ACCESS_TOKEN)
+    return PosterInstagram()
+
+
+def test_authenticate_keeps_access_token_out_of_query_params(monkeypatch):
+    poster = build_poster(monkeypatch)
+    response = Mock()
+
+    with patch(
+        "social_posters.instagram.requests.get",
+        return_value=response,
+    ) as request_get:
+        assert poster.authenticate() is True
+
+    request_get.assert_called_once_with(
+        f"{GRAPH_API_BASE}/{ACCOUNT_ID}",
+        params={"fields": "id,username"},
+        headers={"Authorization": f"Bearer {ACCESS_TOKEN}"},
+        timeout=10,
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_create_media_container_uses_authorization_header(monkeypatch):
+    poster = build_poster(monkeypatch)
+    response = Mock()
+    response.json.return_value = {"id": "container-id"}
+    post = Post(text="Meet Poppy!", image_url="https://example.com/poppy.jpg")
+
+    with patch(
+        "social_posters.instagram.requests.post",
+        return_value=response,
+    ) as request_post:
+        container_id = poster._create_media_container(post)
+
+    assert container_id == "container-id"
+    request_post.assert_called_once_with(
+        f"{GRAPH_API_BASE}/{ACCOUNT_ID}/media",
+        headers={"Authorization": f"Bearer {ACCESS_TOKEN}"},
+        data={
+            "image_url": "https://example.com/poppy.jpg",
+            "caption": "Meet Poppy!",
+        },
+        timeout=30,
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_publish_media_uses_authorization_header(monkeypatch):
+    poster = build_poster(monkeypatch)
+    response = Mock()
+    response.json.return_value = {"id": "media-id"}
+
+    with patch(
+        "social_posters.instagram.requests.post",
+        return_value=response,
+    ) as request_post:
+        media_id = poster._publish_media("container-id")
+
+    assert media_id == "media-id"
+    request_post.assert_called_once_with(
+        f"{GRAPH_API_BASE}/{ACCOUNT_ID}/media_publish",
+        headers={"Authorization": f"Bearer {ACCESS_TOKEN}"},
+        data={"creation_id": "container-id"},
+        timeout=30,
+    )
+    response.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
## Summary

- send Instagram Graph API credentials through the `Authorization` header instead of request query/body parameters
- add regression coverage for authentication, media-container creation, and publishing requests

This keeps the access token out of request URLs and urllib3 debug logs.

## Tests

- `.venv/bin/python -m pytest -q` — 112 passed, 1 skipped

Closes #159