### PR TITLE
Fix debug flags defaulting to disabled on push-triggered runs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -77,8 +77,8 @@ jobs:
           MASTODON_TOKEN: ${{ secrets.MASTODON_TEST_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           APP_ENV: dev
-          DEBUG_SOURCES: ${{ inputs.debugsources != false }}
-          DEBUG_POSTERS: ${{ inputs.debugposters != false }}
+          DEBUG_SOURCES: ${{ github.event_name != 'workflow_dispatch' || inputs.debugsources }}
+          DEBUG_POSTERS: ${{ github.event_name != 'workflow_dispatch' || inputs.debugposters }}
         run: |
           #In order to create posts on the test accounts remove the --debugposters debug flag
           FLAGS=""


### PR DESCRIPTION
## Summary
- PR #151 added `workflow_dispatch` inputs for `debugsources`/`debugposters` and set `DEBUG_SOURCES`/`DEBUG_POSTERS` env vars via `inputs.debugsources != false`, assuming `undefined != false` is `true` on push-triggered runs (no `inputs` context).
- GitHub Actions expressions coerce mismatched types to numbers for comparison: `null` → `0`, `false` → `0`, so `null != false` actually evaluates to `false`. On `push` runs this silently disabled both debug flags instead of preserving the previous hardcoded `--debugsources --debugposters` behavior.
- Fix: explicitly branch on `github.event_name` instead of relying on null/boolean coercion, so push runs always debug and `workflow_dispatch` runs respect the manual input.
- Addresses #163 

## Test plan
- [x] Validated `.github/workflows/dev.yml` still parses via `yaml.safe_load`
- [x] Trigger a push run and confirm `--debugsources --debugposters` are applied (mock sources/posters used)
- [x] Trigger `workflow_dispatch` with both inputs set to `false` and confirm the flags are omitted (live API/posters used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)